### PR TITLE
missing ; while make -j wasmjit

### DIFF
--- a/src/wasmjit/emscripten_runtime.c
+++ b/src/wasmjit/emscripten_runtime.c
@@ -2280,7 +2280,7 @@ static long finish_sendmsg(struct FuncInst *funcinst,
 			return -EFAULT;
 		}
 
-		base = wasmjit_emscripten_get_base_address(funcinst)
+		base = wasmjit_emscripten_get_base_address(funcinst);
 
 		if (read_sockaddr(&ss, &ptr_size, base + msg_name, msg->msg_namelen))
 			return -EINVAL;


### PR DESCRIPTION
➜  wasmjit git:(master) ✗ date
Thu Sep 27 12:57:13 IST 2018

➜  wasmjit git:(master) make -j wasmjit
cc -c -o src/wasmjit/main.o src/wasmjit/main.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/vector.o src/wasmjit/vector.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/ast.o src/wasmjit/ast.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/parse.o src/wasmjit/parse.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/ast_dump.o src/wasmjit/ast_dump.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/compile.o src/wasmjit/compile.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/runtime.o src/wasmjit/runtime.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/util.o src/wasmjit/util.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/elf_relocatable.o src/wasmjit/elf_relocatable.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/dynamic_emscripten_runtime.o src/wasmjit/dynamic_emscripten_runtime.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/emscripten_runtime_sys_posix.o src/wasmjit/emscripten_runtime_sys_posix.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/instantiate.o src/wasmjit/instantiate.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/emscripten_runtime.o src/wasmjit/emscripten_runtime.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/high_level.o src/wasmjit/high_level.c -Isrc -g -Wall -Wextra -Werror
cc -c -o src/wasmjit/dynamic_runtime.o src/wasmjit/dynamic_runtime.c -Isrc -g -Wall -Wextra -Werror


src/wasmjit/emscripten_runtime.c:2283:55: error: expected ';' after expression
                base = wasmjit_emscripten_get_base_address(funcinst)
                                                                    ^
                                                                    ;
1 error generated.
make: *** [src/wasmjit/emscripten_runtime.o] Error 1
make: *** Waiting for unfinished jobs....